### PR TITLE
Include ^ to @mmt-webpack to ensure users receive minor updates

### DIFF
--- a/generators/templates/shared/package.json
+++ b/generators/templates/shared/package.json
@@ -22,14 +22,14 @@
   "author": "MMT Digital",
   "license": "UNLICENSED",
   "dependencies": {
-    "core-js": "2.5.x",
-    "domready": "1.0.x",
-    "regenerator-runtime": "0.12.x"
+    "core-js": "^2.5.7",
+    "domready": "^1.0.8",
+    "regenerator-runtime": "^0.12.1"
   },
   "devDependencies": {
     "@mmtdigital/mmt-webpack": "^0.1.0",
-    "cross-env": "5.2.x",
-    "husky": "1.1.x",
-    "lint-staged": "8.0.x"
+    "cross-env": "^5.2.0",
+    "husky": "^1.1.4",
+    "lint-staged": "^8.0.4"
   }
 }

--- a/generators/templates/shared/package.json
+++ b/generators/templates/shared/package.json
@@ -27,7 +27,7 @@
     "regenerator-runtime": "0.12.x"
   },
   "devDependencies": {
-    "@mmtdigital/mmt-webpack": "0.1.0",
+    "@mmtdigital/mmt-webpack": "^0.1.0",
     "cross-env": "5.2.x",
     "husky": "1.1.x",
     "lint-staged": "8.0.x"


### PR DESCRIPTION
In the simplest terms, the tilde matches the most recent minor version (the middle number). ~1.2.3 will match all 1.2.x versions but will miss 1.3.0.

The caret, on the other hand, is more relaxed. It will update you to the most recent major version (the first number). ^1.2.3 will match any 1.x.x release including 1.3.0, but will hold off on 2.0.0.